### PR TITLE
Allow smooth startup with defined config volumes

### DIFF
--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -43,7 +43,12 @@ elif [[ ! -d /config/www/organizr/.git ]]; then
   echo '| Installing Organizr |'
   echo '-----------------------'
   mkdir -p /config/www/organizr
-  git clone --progress --verbose -b "$(cat /Docker.txt)" https://github.com/causefx/Organizr /config/www/organizr || exit 1
+  git clone --progress --verbose -b "$(cat /Docker.txt)" https://github.com/causefx/Organizr /tmp/organizr || exit 1
+
+  mv -fu /tmp/organizr /config/www/organizr
+
+  rm -rf /tmp/organizr
+
   cd /config/www/organizr || (
     echo 'Failed to load Organizr repository folder'
     exit

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -45,7 +45,7 @@ elif [[ ! -d /config/www/organizr/.git ]]; then
   mkdir -p /config/www/organizr
   git clone --progress --verbose -b "$(cat /Docker.txt)" https://github.com/causefx/Organizr /tmp/organizr || exit 1
 
-  mv -fu /tmp/organizr /config/www/organizr
+  mv -f /tmp/organizr /config/www/organizr
 
   rm -rf /tmp/organizr
 


### PR DESCRIPTION
 Currently if you have a volume binding pointing anywhere under /config/www/organizr the container will fail to startup unless you first remove the volume declaration and let it install organizr, this should fix that. (I can't test it locally because I can't pull the image this is based on :/)