### PR TITLE
Make nginx listen on both address families

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,6 +1,7 @@
 # V0.0.5
 server {
   listen 80 default_server;
+  listen [::]:80 default_server;
   root /config/www/organizr;
   index index.html index.htm index.php;
 


### PR DESCRIPTION
I noticed organizr wasn't accessible over IPv6 so this should fix it.