### PR TITLE
Add default php-local.ini with 512M memory limit

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,4 +1,4 @@
-# V0.0.5
+# V0.0.6
 server {
   listen 80 default_server;
   root /config/www/organizr;
@@ -7,14 +7,23 @@ server {
   server_name _;
   client_max_body_size 0;
 
+  # Hide nginx version
+  server_tokens off;
+
   # Real Docker IP
   # Make sure to update the IP range with your Docker IP subnet
   real_ip_header X-Forwarded-For;
   #set_real_ip_from 172.17.0.0/16;
   real_ip_recursive on;
 
-  # Deny access to Org .git directory
+  # Deny access to sensitive files and directories
   location ~ /\.git {
+    deny all;
+  }
+  location ~ /\.env {
+    deny all;
+  }
+  location ~ /\.ht {
     deny all;
   }
 

--- a/root/defaults/php-local.ini
+++ b/root/defaults/php-local.ini
@@ -1,0 +1,3 @@
+; Organizr PHP Configuration
+; Increase memory limit for large datasets (JellyStat history, logs, etc.)
+memory_limit = 512M

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -68,7 +68,7 @@ elif [[ -d /config/www/organizr/.git ]]; then
   git reset --hard origin/"$(cat /Docker.txt)"
   git pull
   git rev-parse HEAD >/config/www/organizr/Github.txt
-elif ! ping -c 1 https://github.com &>/dev/null; then
+elif ! ping -c 1 github.com &>/dev/null; then
   echo "Git clone failed, but github is resolvable"
 else
   echo "Git clone failed"

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -36,7 +36,7 @@ if [[ $(grep -c "location /api/v2 {" /config/nginx/site-confs/default) -eq 0 ]];
   printf "Api location for api version 2 is not found.\nPlease visit https://organizr.app/v2-api and follow the instructions.\n"
 fi
 
-# Fetch site or update existing
+# Fetch site or update existing
 if [ "$branch" == "manual" ]; then
   echo "Skipping update"
 elif [[ ! -d /config/www/organizr/.git ]]; then
@@ -93,6 +93,15 @@ cp /Docker.txt /config/www/organizr/Docker.txt || (
   exit 0
 )
 
-# Set Permissions
+# Set up php-local.ini with recommended memory limit if not exists
+if [ ! -f /config/php/php-local.ini ]; then
+  echo '-------------------------'
+  echo '| Setting up PHP config |'
+  echo '-------------------------'
+  mkdir -p /config/php
+  cp /defaults/php-local.ini /config/php/php-local.ini
+fi
+
+# Set Permissions
 lsiown -R abc:abc \
   /config


### PR DESCRIPTION
- Create /defaults/php-local.ini with memory_limit = 512M
- Update 40-install to copy php-local.ini on new installs
- Prevents memory exhaustion with large datasets (JellyStat history, logs)